### PR TITLE
Add nok functionality

### DIFF
--- a/src/main/java/seedu/address/logic/commands/NokCommand.java
+++ b/src/main/java/seedu/address/logic/commands/NokCommand.java
@@ -1,0 +1,173 @@
+package seedu.address.logic.commands;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.commons.core.index.Index;
+import seedu.address.commons.util.CollectionUtil;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.person.Address;
+import seedu.address.model.person.Email;
+import seedu.address.model.person.Name;
+import seedu.address.model.person.Nok;
+import seedu.address.model.person.Person;
+import seedu.address.model.person.Phone;
+import seedu.address.model.tag.Tag;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
+
+/**
+ * Adds a person related to somebody else in the address book.
+ */
+public class NokCommand extends Command {
+    public static final String COMMAND_WORD = "nok";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a next-of-kin to a person identified by the index number "
+            + "used in the displayed person's list. "
+            + "Parameters: INDEX (must be a positive integer) "
+            + "[" + PREFIX_NAME + "NAME] "
+            + "[" + PREFIX_PHONE + "PHONE] "
+            + "[" + PREFIX_EMAIL + "EMAIL] "
+            + "[" + PREFIX_ADDRESS + "ADDRESS] "
+            + "[" + PREFIX_TAG + "TAG]...\n"
+            + "Example: " + COMMAND_WORD + " 1 "
+            + PREFIX_PHONE + "91234567 "
+            + PREFIX_EMAIL + "johndoe@example.com";
+
+    public static final String MESSAGE_NOK_SUCCESS = "New nok added: %1$s";
+    public static final String MESSAGE_NOK_NOT_SET = "At least one field to add must be provided.";
+    public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists in the address book.";
+
+    private final Index index;
+    private final Nok nokToAdd;
+
+    /**
+     * Creates an AddCommand to add the specified {@code Person}
+     */
+    public NokCommand(Index index, Nok nok) {
+        requireNonNull(nok);
+        this.index = index;
+        this.nokToAdd = nok;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        List<Person> lastShownList = model.getFilteredPersonList();
+
+        if (index.getZeroBased() >= lastShownList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        }
+
+        Person personToEdit = lastShownList.get(index.getZeroBased());
+
+        personToEdit.setNok(nokToAdd);
+
+        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+        return new CommandResult(String.format(MESSAGE_NOK_SUCCESS, nokToAdd));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof NokCommand // instanceof handles nulls
+                && nokToAdd.equals(((NokCommand) other).nokToAdd));
+    }
+
+
+    /**
+     * Stores the details to edit the person with. Each non-empty field value will replace the
+     * corresponding field value of the person.
+     */
+    public static class NokPersonDescriptor {
+        private Name name;
+        private Phone phone;
+        private Email email;
+        private Address address;
+
+        public NokPersonDescriptor() {
+        }
+
+        /**
+         * Copy constructor.
+         * A defensive copy of {@code tags} is used internally.
+         */
+        public NokPersonDescriptor(NokPersonDescriptor toCopy) {
+            setName(toCopy.name);
+            setPhone(toCopy.phone);
+            setEmail(toCopy.email);
+            setAddress(toCopy.address);
+        }
+
+        /**
+         * Returns true if at least one field is edited.
+         */
+        public boolean isAnyFieldEdited() {
+            return CollectionUtil.isAnyNonNull(name, phone, email, address);
+        }
+
+        public void setName(Name name) {
+            this.name = name;
+        }
+
+        public Optional<Name> getName() {
+            return Optional.ofNullable(name);
+        }
+
+        public void setPhone(Phone phone) {
+            this.phone = phone;
+        }
+
+        public Optional<Phone> getPhone() {
+            return Optional.ofNullable(phone);
+        }
+
+        public void setEmail(Email email) {
+            this.email = email;
+        }
+
+        public Optional<Email> getEmail() {
+            return Optional.ofNullable(email);
+        }
+
+        public void setAddress(Address address) {
+            this.address = address;
+        }
+
+        public Optional<Address> getAddress() {
+            return Optional.ofNullable(address);
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            // short circuit if same object
+            if (other == this) {
+                return true;
+            }
+
+            // instanceof handles nulls
+            if (!(other instanceof EditCommand.EditPersonDescriptor)) {
+                return false;
+            }
+
+            // state check
+            EditCommand.EditPersonDescriptor e = (EditCommand.EditPersonDescriptor) other;
+
+            return getName().equals(e.getName())
+                    && getPhone().equals(e.getPhone())
+                    && getEmail().equals(e.getEmail())
+                    && getAddress().equals(e.getAddress());
+        }
+    }
+
+
+}

--- a/src/main/java/seedu/address/logic/commands/NokCommand.java
+++ b/src/main/java/seedu/address/logic/commands/NokCommand.java
@@ -1,5 +1,16 @@
 package seedu.address.logic.commands;
 
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
+
+import java.util.List;
+import java.util.Optional;
+
 import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.CollectionUtil;
@@ -11,19 +22,6 @@ import seedu.address.model.person.Name;
 import seedu.address.model.person.Nok;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
-import seedu.address.model.tag.Tag;
-
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
-
-import static java.util.Objects.requireNonNull;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
-import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
 /**
  * Adds a person related to somebody else in the address book.
@@ -31,8 +29,8 @@ import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 public class NokCommand extends Command {
     public static final String COMMAND_WORD = "nok";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a next-of-kin to a person identified by the index number "
-            + "used in the displayed person's list. "
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a next-of-kin to a person identified by "
+            + "the index number used in the displayed person's list. "
             + "Parameters: INDEX (must be a positive integer) "
             + "[" + PREFIX_NAME + "NAME] "
             + "[" + PREFIX_PHONE + "PHONE] "

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -15,6 +15,7 @@ import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.commands.NokCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
@@ -67,6 +68,9 @@ public class AddressBookParser {
 
         case HelpCommand.COMMAND_WORD:
             return new HelpCommand();
+
+        case NokCommand.COMMAND_WORD:
+            return new NokCommandParser().parse(arguments);
 
         default:
             throw new ParseException(MESSAGE_UNKNOWN_COMMAND);

--- a/src/main/java/seedu/address/logic/parser/NokCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/NokCommandParser.java
@@ -1,5 +1,18 @@
 package seedu.address.logic.parser;
 
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.Set;
+
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.NokCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -10,18 +23,6 @@ import seedu.address.model.person.Nok;
 import seedu.address.model.person.Phone;
 import seedu.address.model.tag.Tag;
 
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Optional;
-import java.util.Set;
-
-import static java.util.Objects.requireNonNull;
-import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
 /**
  * Parses input arguments and creates a new NokCommand object

--- a/src/main/java/seedu/address/logic/parser/NokCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/NokCommandParser.java
@@ -1,6 +1,5 @@
 package seedu.address.logic.parser;
 
-
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.NokCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -10,7 +9,6 @@ import seedu.address.model.person.Name;
 import seedu.address.model.person.Nok;
 import seedu.address.model.person.Phone;
 import seedu.address.model.tag.Tag;
-import seedu.address.logic.commands.NokCommand.NokPersonDescriptor;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -47,6 +45,7 @@ public class NokCommandParser implements Parser<NokCommand> {
         } catch (ParseException pe) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, NokCommand.MESSAGE_USAGE), pe);
         }
+
         Name name = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get());
         Phone phone = ParserUtil.parsePhone(argMultimap.getValue(PREFIX_PHONE).get());
         Email email = ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL).get());

--- a/src/main/java/seedu/address/logic/parser/NokCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/NokCommandParser.java
@@ -1,0 +1,75 @@
+package seedu.address.logic.parser;
+
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.NokCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.person.Address;
+import seedu.address.model.person.Email;
+import seedu.address.model.person.Name;
+import seedu.address.model.person.Nok;
+import seedu.address.model.person.Phone;
+import seedu.address.model.tag.Tag;
+import seedu.address.logic.commands.NokCommand.NokPersonDescriptor;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.Set;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+
+/**
+ * Parses input arguments and creates a new NokCommand object
+ */
+public class NokCommandParser implements Parser<NokCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the NokCommand
+     * and returns an NokCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public NokCommand parse(String args) throws ParseException {
+        requireNonNull(args);
+        ArgumentMultimap argMultimap =
+                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_TAG);
+
+        Index index;
+
+        try {
+            index = ParserUtil.parseIndex(argMultimap.getPreamble());
+        } catch (ParseException pe) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, NokCommand.MESSAGE_USAGE), pe);
+        }
+        Name name = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get());
+        Phone phone = ParserUtil.parsePhone(argMultimap.getValue(PREFIX_PHONE).get());
+        Email email = ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL).get());
+        Address address = ParserUtil.parseAddress(argMultimap.getValue(PREFIX_ADDRESS).get());
+
+        Nok nok = new Nok(name, phone, email, address);
+
+        return new NokCommand(index, nok);
+    }
+
+    /**
+     * Parses {@code Collection<String> tags} into a {@code Set<Tag>} if {@code tags} is non-empty.
+     * If {@code tags} contain only one element which is an empty string, it will be parsed into a
+     * {@code Set<Tag>} containing zero tags.
+     */
+    private Optional<Set<Tag>> parseTagsForEdit(Collection<String> tags) throws ParseException {
+        assert tags != null;
+
+        if (tags.isEmpty()) {
+            return Optional.empty();
+        }
+        Collection<String> tagSet = tags.size() == 1 && tags.contains("") ? Collections.emptySet() : tags;
+        return Optional.of(ParserUtil.parseTags(tagSet));
+    }
+
+}

--- a/src/main/java/seedu/address/model/person/Nok.java
+++ b/src/main/java/seedu/address/model/person/Nok.java
@@ -1,12 +1,5 @@
 package seedu.address.model.person;
 
-import seedu.address.model.tag.Tag;
-
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Objects;
-import java.util.Set;
-
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 public class Nok {

--- a/src/main/java/seedu/address/model/person/Nok.java
+++ b/src/main/java/seedu/address/model/person/Nok.java
@@ -1,28 +1,15 @@
 package seedu.address.model.person;
 
-import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
+import seedu.address.model.tag.Tag;
 
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
 
-import seedu.address.model.tag.Tag;
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
-/**
- * Represents a Person in the address book.
- * Guarantees: details are present and not null, field values are validated, immutable.
- */
-public class Person {
-
-    /* Each Person has 0..1 Noks */
-    /**
-     * TODO: To prevent repeat of information, rename Person to Student such that
-     *     _both_ Nok and Student inherits from Person (to share common fields)
-     *     For now, Nok and Person has duplicate fields.
-     */
-    private Nok nok;
-
+public class Nok {
     // Identity fields
     private final Name name;
     private final Phone phone;
@@ -30,22 +17,16 @@ public class Person {
 
     // Data fields
     private final Address address;
-    private final Set<Tag> tags = new HashSet<>();
 
     /**
      * Every field must be present and not null.
      */
-    public Person(Name name, Phone phone, Email email, Address address, Set<Tag> tags) {
-        requireAllNonNull(name, phone, email, address, tags);
+    public Nok(Name name, Phone phone, Email email, Address address) {
+        requireAllNonNull(name, phone, email, address);
         this.name = name;
         this.phone = phone;
         this.email = email;
         this.address = address;
-        this.tags.addAll(tags);
-    }
-
-    public void setNok(Nok nok) {
-        this.nok = nok;
     }
 
     public Name getName() {
@@ -65,18 +46,10 @@ public class Person {
     }
 
     /**
-     * Returns an immutable tag set, which throws {@code UnsupportedOperationException}
-     * if modification is attempted.
-     */
-    public Set<Tag> getTags() {
-        return Collections.unmodifiableSet(tags);
-    }
-
-    /**
      * Returns true if both persons have the same name.
      * This defines a weaker notion of equality between two persons.
      */
-    public boolean isSamePerson(Person otherPerson) {
+    public boolean isSamePerson(Nok otherPerson) {
         if (otherPerson == this) {
             return true;
         }
@@ -103,14 +76,7 @@ public class Person {
         return otherPerson.getName().equals(getName())
                 && otherPerson.getPhone().equals(getPhone())
                 && otherPerson.getEmail().equals(getEmail())
-                && otherPerson.getAddress().equals(getAddress())
-                && otherPerson.getTags().equals(getTags());
-    }
-
-    @Override
-    public int hashCode() {
-        // use this method for custom fields hashing instead of implementing your own
-        return Objects.hash(name, phone, email, address, tags);
+                && otherPerson.getAddress().equals(getAddress());
     }
 
     @Override
@@ -124,12 +90,6 @@ public class Person {
                 .append("; Address: ")
                 .append(getAddress());
 
-        Set<Tag> tags = getTags();
-        if (!tags.isEmpty()) {
-            builder.append("; Tags: ");
-            tags.forEach(builder::append);
-        }
         return builder.toString();
     }
-
 }

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -52,6 +52,10 @@ public class Person {
         return name;
     }
 
+    public Nok getNok() {
+        return nok;
+    }
+
     public Phone getPhone() {
         return phone;
     }

--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -26,6 +26,7 @@ public class PersonCard extends UiPart<Region> {
 
     public final Person person;
 
+    // Student
     @FXML
     private HBox cardPane;
     @FXML
@@ -41,17 +42,38 @@ public class PersonCard extends UiPart<Region> {
     @FXML
     private FlowPane tags;
 
+    // Nok
+    @FXML
+    private Label nok_name;
+    @FXML
+    private Label nok_phone;
+    @FXML
+    private Label nok_address;
+    @FXML
+    private Label nok_email;
+
     /**
      * Creates a {@code PersonCode} with the given {@code Person} and index to display.
      */
     public PersonCard(Person person, int displayedIndex) {
         super(FXML);
         this.person = person;
+
+        // Student
         id.setText(displayedIndex + ". ");
         name.setText(person.getName().fullName);
         phone.setText(person.getPhone().value);
         address.setText(person.getAddress().value);
         email.setText(person.getEmail().value);
+
+        // Nok
+        if (person.getNok() != null) {
+            nok_name.setText(person.getNok().getName().fullName);
+            nok_phone.setText(person.getNok().getPhone().value);
+            nok_address.setText(person.getNok().getAddress().value);
+            nok_email.setText(person.getNok().getEmail().value);
+        }
+
         person.getTags().stream()
                 .sorted(Comparator.comparing(tag -> tag.tagName))
                 .forEach(tag -> tags.getChildren().add(new Label(tag.tagName)));

--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -44,13 +44,13 @@ public class PersonCard extends UiPart<Region> {
 
     // Nok
     @FXML
-    private Label nok_name;
+    private Label nokName;
     @FXML
-    private Label nok_phone;
+    private Label nokPhone;
     @FXML
-    private Label nok_address;
+    private Label nokAddress;
     @FXML
-    private Label nok_email;
+    private Label nokEmail;
 
     /**
      * Creates a {@code PersonCode} with the given {@code Person} and index to display.
@@ -68,10 +68,10 @@ public class PersonCard extends UiPart<Region> {
 
         // Nok
         if (person.getNok() != null) {
-            nok_name.setText(person.getNok().getName().fullName);
-            nok_phone.setText(person.getNok().getPhone().value);
-            nok_address.setText(person.getNok().getAddress().value);
-            nok_email.setText(person.getNok().getEmail().value);
+            nokName.setText(person.getNok().getName().fullName);
+            nokPhone.setText(person.getNok().getPhone().value);
+            nokAddress.setText(person.getNok().getAddress().value);
+            nokEmail.setText(person.getNok().getEmail().value);
         }
 
         person.getTags().stream()

--- a/src/main/resources/view/PersonListCard.fxml
+++ b/src/main/resources/view/PersonListCard.fxml
@@ -37,12 +37,12 @@
         <Insets top="5" right="5" bottom="5" left="15" />
       </padding>
       <HBox spacing="5" alignment="CENTER_RIGHT">
-        <Label fx:id="nok_name" text="\$first" styleClass="cell_big_label" />
+        <Label fx:id="nok_name" text="\$nok_first" styleClass="cell_big_label" />
       </HBox>
       <FlowPane />
-      <Label fx:id="nok_phone" styleClass="cell_small_label" text="\$phone" />
-      <Label fx:id="nok_address" styleClass="cell_small_label" text="\$address" />
-      <Label fx:id="nok_email" styleClass="cell_small_label" text="\$email" />
+      <Label fx:id="nok_phone" styleClass="cell_small_label" text="\$nok_phone" />
+      <Label fx:id="nok_address" styleClass="cell_small_label" text="\$nok_address" />
+      <Label fx:id="nok_email" styleClass="cell_small_label" text="\$nok_email" />
     </VBox>
   </GridPane>
 </HBox>

--- a/src/main/resources/view/PersonListCard.fxml
+++ b/src/main/resources/view/PersonListCard.fxml
@@ -32,5 +32,17 @@
       <Label fx:id="address" styleClass="cell_small_label" text="\$address" />
       <Label fx:id="email" styleClass="cell_small_label" text="\$email" />
     </VBox>
+    <VBox alignment="CENTER_RIGHT" minHeight="105" GridPane.columnIndex="0">
+      <padding>
+        <Insets top="5" right="5" bottom="5" left="15" />
+      </padding>
+      <HBox spacing="5" alignment="CENTER_RIGHT">
+        <Label fx:id="nok_name" text="\$first" styleClass="cell_big_label" />
+      </HBox>
+      <FlowPane />
+      <Label fx:id="nok_phone" styleClass="cell_small_label" text="\$phone" />
+      <Label fx:id="nok_address" styleClass="cell_small_label" text="\$address" />
+      <Label fx:id="nok_email" styleClass="cell_small_label" text="\$email" />
+    </VBox>
   </GridPane>
 </HBox>

--- a/src/main/resources/view/PersonListCard.fxml
+++ b/src/main/resources/view/PersonListCard.fxml
@@ -37,12 +37,12 @@
         <Insets top="5" right="5" bottom="5" left="15" />
       </padding>
       <HBox spacing="5" alignment="CENTER_RIGHT">
-        <Label fx:id="nok_name" text="\$nok_first" styleClass="cell_big_label" />
+        <Label fx:id="nokName" text="\$nok_first" styleClass="cell_big_label" />
       </HBox>
       <FlowPane />
-      <Label fx:id="nok_phone" styleClass="cell_small_label" text="\$nok_phone" />
-      <Label fx:id="nok_address" styleClass="cell_small_label" text="\$nok_address" />
-      <Label fx:id="nok_email" styleClass="cell_small_label" text="\$nok_email" />
+      <Label fx:id="nokPhone" styleClass="cell_small_label" text="\$nok_phone" />
+      <Label fx:id="nokAddress" styleClass="cell_small_label" text="\$nok_address" />
+      <Label fx:id="nokEmail" styleClass="cell_small_label" text="\$nok_email" />
     </VBox>
   </GridPane>
 </HBox>

--- a/src/test/java/seedu/address/testutil/PersonBuilder.java
+++ b/src/test/java/seedu/address/testutil/PersonBuilder.java
@@ -90,7 +90,7 @@ public class PersonBuilder {
     }
 
     public Person build() {
-        return new Person(name, phone, email, address, tags);
+        return new Person(name, phone, email, address, tags, nok);
     }
 
 }

--- a/src/test/java/seedu/address/testutil/PersonBuilder.java
+++ b/src/test/java/seedu/address/testutil/PersonBuilder.java
@@ -90,7 +90,7 @@ public class PersonBuilder {
     }
 
     public Person build() {
-        return new Person(name, phone, email, address, tags, nok);
+        return new Person(name, phone, email, address, tags);
     }
 
 }


### PR DESCRIPTION
Very very bare bones implementation of the Nok system: `nok <index> n/<name> p/<number> a/<address> e/<email>`
Things to note:
- A Person can have 0..1 Noks
- Therefore I have put placeholder text for Persons without Noks (We can try to remove the right-centred GUI altogether for Persons without Noks)
- Currently, the fields for Persons and Noks are duplicated (name, phone, email, address). I foresee that we can rename Person to Student such that both Nok and Student inherit similar fields from Person. This is so that we avoid duplicate fields (Done!)
- Currently ALL fields are required for an Nok to be created, otherwise an error is thrown.
- Nok information is not saved as json using Jackson

Sample command to test: `nok 1 n/hehe p/1234567 e/hehe@gmail.com a/Newgate prison`
![image](https://user-images.githubusercontent.com/45702380/135302462-78fdfbaf-9cf1-45de-b2ed-fc3559e0ae6b.png)
